### PR TITLE
Add sub element and xml element tests

### DIFF
--- a/exporter/components/xml/invoice.py
+++ b/exporter/components/xml/invoice.py
@@ -26,6 +26,9 @@ class XMLElement:
     def set_text(self, text: str | None = None) -> None:
         self.element.text = text
 
+    def add_sub_element(self, tag: str) -> 'XMLElement':
+        return XMLElement(SubElement(self.element, tag))
+
 
 # fmt: off
 @dataclass
@@ -34,19 +37,19 @@ class Invoice:
     Sets up the XML structure to be used for conversion.
     """
     root: XMLElement = XMLElement(Element("InvoiceRegisters"))
-    invoices: XMLElement = XMLElement(SubElement(root.element, "Invoices"))
-    payable: XMLElement = XMLElement(SubElement(invoices.element, "Payable"))
-    invoice_number: XMLElement = XMLElement(SubElement(payable.element, "InvoiceNumber"))
-    invoice_date: XMLElement = XMLElement(SubElement(payable.element, "InvoiceDate"))
-    due_date: XMLElement = XMLElement(SubElement(payable.element, "DueDate"))
-    total_amount: XMLElement = XMLElement(SubElement(payable.element, "TotalAmount"))
-    notes: XMLElement = XMLElement(SubElement(payable.element, "Notes"))
-    iban: XMLElement = XMLElement(SubElement(payable.element, "Iban"))
-    amount: XMLElement = XMLElement(SubElement(payable.element, "Amount"))
-    currency: XMLElement = XMLElement(SubElement(payable.element, "Currency"))
-    vendor: XMLElement = XMLElement(SubElement(payable.element, "Vendor"))
-    vendor_address: XMLElement = XMLElement(SubElement(payable.element, "VendorAddress"))
-    details: XMLElement = XMLElement(SubElement(payable.element, "Details"))
+    invoices: XMLElement = root.add_sub_element("Invoices")
+    payable: XMLElement = root.add_sub_element("Payable")
+    invoice_number: XMLElement = payable.add_sub_element("InvoiceNumber")
+    invoice_date: XMLElement = payable.add_sub_element("InvoiceDate")
+    due_date: XMLElement = payable.add_sub_element("DueDate")
+    total_amount: XMLElement = payable.add_sub_element("TotalAmount")
+    notes: XMLElement = payable.add_sub_element("Notes")
+    iban: XMLElement = payable.add_sub_element("Iban")
+    amount: XMLElement = payable.add_sub_element("Amount")
+    currency: XMLElement = payable.add_sub_element("Currency")
+    vendor: XMLElement = payable.add_sub_element("Vendor")
+    vendor_address: XMLElement = payable.add_sub_element("VendorAddress")
+    details: XMLElement = payable.add_sub_element("Details")
 
     def to_byte_string(self) -> bytes:
         return base64.b64encode(tostring(self.root.element, encoding='utf8', method='xml'))

--- a/exporter/components/xml/invoice.py
+++ b/exporter/components/xml/invoice.py
@@ -38,7 +38,7 @@ class Invoice:
     """
     root: XMLElement = XMLElement(Element("InvoiceRegisters"))
     invoices: XMLElement = root.add_sub_element("Invoices")
-    payable: XMLElement = root.add_sub_element("Payable")
+    payable: XMLElement = invoices.add_sub_element("Payable")
     invoice_number: XMLElement = payable.add_sub_element("InvoiceNumber")
     invoice_date: XMLElement = payable.add_sub_element("InvoiceDate")
     due_date: XMLElement = payable.add_sub_element("DueDate")
@@ -61,8 +61,8 @@ class InvoiceDetail():
     """
     def __init__(self, detail_element: XMLElement) -> None:
         self.detail: XMLElement = detail_element
-        self.amount: XMLElement = XMLElement(SubElement(self.detail.element, "Amount"))
-        self.account_id: XMLElement = XMLElement(SubElement(self.detail.element, "AccountId"))
-        self.quantity: XMLElement = XMLElement(SubElement(self.detail.element, "Quantity"))
-        self.notes: XMLElement = XMLElement(SubElement(self.detail.element, "Notes"))
+        self.amount: XMLElement = self.detail.add_sub_element("Amount")
+        self.account_id: XMLElement = self.detail.add_sub_element("AccountId")
+        self.quantity: XMLElement = self.detail.add_sub_element("Quantity")
+        self.notes: XMLElement = self.detail.add_sub_element("Notes")
 # fmt: on

--- a/tests/exporter/test_xml_element.py
+++ b/tests/exporter/test_xml_element.py
@@ -1,0 +1,81 @@
+import pytest
+
+from xml.etree.ElementTree import Element, fromstring, tostring
+from exporter.components.xml.invoice import XMLElement
+from exporter.components.xml.exporter import InvoiceExporter
+
+
+class TestElements:
+    # fmt: off
+    @pytest.fixture
+    def valid_xml(self) -> bytes:
+        return b"""<?xml version="1.0" encoding="utf-8"?>
+        <result>
+            <datapoint schema_id="id">12345</datapoint>
+            <datapoint>No schema id here</datapoint>
+            <tuple schema_id="line_item">
+                <datapoint schema_id="first_name">First</datapoint>
+                <datapoint schema_id="last_name">Last</datapoint>
+            </tuple>
+            <tuple schema_id="line_item">
+                <datapoint schema_id="age">55</datapoint>
+            </tuple>
+            <tuple schema_id="line_item">
+                <datapoint schema_id="number">123456789</datapoint>
+                <datapoint schema_id="no_text"></datapoint>
+                <datapoint>No schema id here either</datapoint>
+            </tuple>
+        </result>
+        """
+
+    @pytest.fixture
+    def valid_multi_element(self, valid_xml) -> Element:
+        return fromstring(valid_xml)
+
+    @pytest.fixture
+    def xml_element(self) -> XMLElement:
+        return XMLElement(Element("New"))
+
+    @pytest.fixture
+    def exporter(self, valid_xml) -> InvoiceExporter:
+        return InvoiceExporter(valid_xml)
+
+    def test_can_create_xml_element_from_existing_element(self, valid_multi_element: Element):
+        assert XMLElement(valid_multi_element).element == valid_multi_element
+
+    def test_can_create_xml_element_from_new_element(self):
+        assert XMLElement(new_element := Element("New")).element == new_element
+
+    def test_can_add_sub_element(self, xml_element: XMLElement):
+        assert xml_element.add_sub_element("Sub").element.tag == "Sub"
+
+    def test_can_set_element_text(self, xml_element: XMLElement):
+        xml_element.set_text(text := "Sample")
+        assert xml_element.element.text == text
+
+    def test_can_set_text_from_dictionary(self, xml_element: XMLElement, exporter: InvoiceExporter):
+        (first_name := xml_element.add_sub_element("FirstName")).set_text(first_name_text := exporter.datapoints.get("first_name"))
+        (last_name := xml_element.add_sub_element("LastName")).set_text(last_name_text := exporter.datapoints.get("last_name"))
+
+        byte_string = tostring(xml_element.element, encoding='utf8', method='xml')
+
+        assert first_name.element.text == first_name_text
+        assert last_name.element.text == last_name_text
+        assert byte_string == b"<?xml version='1.0' encoding='utf8'?>\n<New><FirstName>First</FirstName><LastName>Last</LastName></New>"
+
+    def test_invoice_exporter(self, exporter: InvoiceExporter):
+        assert exporter.datapoints == {
+            'id': '12345',
+            'first_name': 'First',
+            'last_name': 'Last',
+            'age': '55',
+            'number': '123456789',
+            'no_text': None
+        }
+        assert exporter.detail_items == [
+            {'first_name': 'First', 'last_name': 'Last'},
+            {'age': '55'},
+            {'number': '123456789', 'no_text': None}
+        ]
+    # fmt: on
+        


### PR DESCRIPTION
Added `add_sub_element` method to `XMLElement`.

This is meant to make the creation of multi element instances more human readable. So instead of

```py
element_one: XMLElement = XMLElement(Element("ElementOne"))
element_two: XMLElement = XMLElement(SubElement(element_one.element, "ElementTwo"))
element_three: XMLElement = XMLElement(SubElement(element_two.element, "ElementThree"))
```

We have the much more easily understood version

```py
element_one: XMLElement = XMLElement(Element("ElementOne"))
element_two: XMLElement = element_one.add_sub_element("ElementTwo")
element_three: XMLElement = element_two.add_sub_element("ElementTwo")
```

The root element, i.e. `element_one`, will still need to be specified for now in the less friendly syntax.

Also added tests for XML elements.