### PR TITLE
Added tests for datapoint date and made safe date conversion in exporter

### DIFF
--- a/exporter/components/xml/exporter.py
+++ b/exporter/components/xml/exporter.py
@@ -72,8 +72,8 @@ class InvoiceExporter:
         the value (if present) into a valid ISO 8601 datetime string.
         Otherwise returns None.
         """
-        date = self.datapoints.get(key)
-        return datetime.strptime(date, "%Y-%m-%d").isoformat() if date else None
+        to_iso = lambda d: datetime.strptime(d, "%Y-%m-%d").isoformat()
+        return to_iso(date) if (date := self._get_datapoint_value(key)) else None
 
     @staticmethod
     def _get_datapoint_text_by_schema_ids(element: Element) -> Dict[str, str | None]:

--- a/exporter/components/xml/exporter.py
+++ b/exporter/components/xml/exporter.py
@@ -71,9 +71,15 @@ class InvoiceExporter:
         Gets the value of the datapoint using the given key. Converts
         the value (if present) into a valid ISO 8601 datetime string.
         Otherwise returns None.
+
+        Currently only accepts a string with the format `%Y-%m-%d` without
+        time. If any other formatted string is passed, will return None.
         """
         to_iso = lambda d: datetime.strptime(d, "%Y-%m-%d").isoformat()
-        return to_iso(date) if (date := self._get_datapoint_value(key)) else None
+        try:
+            return to_iso(date) if (date := self._get_datapoint_value(key)) else None
+        except ValueError:
+            return None
 
     @staticmethod
     def _get_datapoint_text_by_schema_ids(element: Element) -> Dict[str, str | None]:

--- a/exporter/components/xml/exporter.py
+++ b/exporter/components/xml/exporter.py
@@ -72,7 +72,7 @@ class InvoiceExporter:
         the value (if present) into a valid ISO 8601 datetime string.
         Otherwise returns None.
 
-        Currently only accepts a string with the format `%Y-%m-%d` without
+        Currently only accepts a string with the format `YYYY-MM-DD` without
         time. If any other formatted string is passed, will return None.
         """
         to_iso = lambda d: datetime.strptime(d, "%Y-%m-%d").isoformat()

--- a/tests/exporter/test_xml_element.py
+++ b/tests/exporter/test_xml_element.py
@@ -25,6 +25,9 @@ class TestElements:
                 <datapoint schema_id="no_text"></datapoint>
                 <datapoint>No schema id here either</datapoint>
             </tuple>
+            <tuple>
+                <datapoint schema_id="birth_date">1990-03-31</datapoint>
+            </tuple>
         </result>
         """
 
@@ -54,14 +57,16 @@ class TestElements:
         assert xml_element.element.text == text
 
     def test_can_set_text_from_dictionary(self, xml_element: XMLElement, exporter: InvoiceExporter):
-        (first_name := xml_element.add_sub_element("FirstName")).set_text(first_name_text := exporter.datapoints.get("first_name"))
-        (last_name := xml_element.add_sub_element("LastName")).set_text(last_name_text := exporter.datapoints.get("last_name"))
+        (first_name := xml_element.add_sub_element("FirstName")).set_text(first_name_text := exporter._get_datapoint_value("first_name"))
+        (last_name := xml_element.add_sub_element("LastName")).set_text(last_name_text := exporter._get_datapoint_value("last_name"))
+        (birth_date := xml_element.add_sub_element("BirthDate")).set_text(birth_date_text := exporter._get_datapoint_date_value("birth_date"))
 
         byte_string = tostring(xml_element.element, encoding='utf8', method='xml')
 
         assert first_name.element.text == first_name_text
         assert last_name.element.text == last_name_text
-        assert byte_string == b"<?xml version='1.0' encoding='utf8'?>\n<New><FirstName>First</FirstName><LastName>Last</LastName></New>"
+        assert birth_date.element.text == birth_date_text
+        assert byte_string == b"<?xml version='1.0' encoding='utf8'?>\n<New><FirstName>First</FirstName><LastName>Last</LastName><BirthDate>1990-03-31T00:00:00</BirthDate></New>"
 
     def test_invoice_exporter(self, exporter: InvoiceExporter):
         assert exporter.datapoints == {
@@ -70,7 +75,8 @@ class TestElements:
             'last_name': 'Last',
             'age': '55',
             'number': '123456789',
-            'no_text': None
+            'no_text': None,
+            'birth_date': '1990-03-31'
         }
         assert exporter.detail_items == [
             {'first_name': 'First', 'last_name': 'Last'},

--- a/tests/exporter/test_xml_element.py
+++ b/tests/exporter/test_xml_element.py
@@ -27,6 +27,7 @@ class TestElements:
             </tuple>
             <tuple>
                 <datapoint schema_id="birth_date">1990-03-31</datapoint>
+                <datapoint schema_id="birth_date_invalid">1990-03-31T00:00:00</datapoint>
             </tuple>
         </result>
         """
@@ -40,7 +41,7 @@ class TestElements:
         return XMLElement(Element("New"))
 
     @pytest.fixture
-    def exporter(self, valid_xml) -> InvoiceExporter:
+    def exporter(self, valid_xml: bytes) -> InvoiceExporter:
         return InvoiceExporter(valid_xml)
 
     def test_can_create_xml_element_from_existing_element(self, valid_multi_element: Element):
@@ -60,13 +61,15 @@ class TestElements:
         (first_name := xml_element.add_sub_element("FirstName")).set_text(first_name_text := exporter._get_datapoint_value("first_name"))
         (last_name := xml_element.add_sub_element("LastName")).set_text(last_name_text := exporter._get_datapoint_value("last_name"))
         (birth_date := xml_element.add_sub_element("BirthDate")).set_text(birth_date_text := exporter._get_datapoint_date_value("birth_date"))
+        (birth_date_invalid := xml_element.add_sub_element("BirthDateInvalid")).set_text(birth_date_invalid_text := exporter._get_datapoint_date_value("birth_date_invalid"))
 
         byte_string = tostring(xml_element.element, encoding='utf8', method='xml')
 
         assert first_name.element.text == first_name_text
         assert last_name.element.text == last_name_text
         assert birth_date.element.text == birth_date_text
-        assert byte_string == b"<?xml version='1.0' encoding='utf8'?>\n<New><FirstName>First</FirstName><LastName>Last</LastName><BirthDate>1990-03-31T00:00:00</BirthDate></New>"
+        assert birth_date_invalid.element.text == birth_date_invalid_text
+        assert byte_string == b"<?xml version='1.0' encoding='utf8'?>\n<New><FirstName>First</FirstName><LastName>Last</LastName><BirthDate>1990-03-31T00:00:00</BirthDate><BirthDateInvalid /></New>"
 
     def test_invoice_exporter(self, exporter: InvoiceExporter):
         assert exporter.datapoints == {
@@ -76,7 +79,8 @@ class TestElements:
             'age': '55',
             'number': '123456789',
             'no_text': None,
-            'birth_date': '1990-03-31'
+            'birth_date': '1990-03-31',
+            'birth_date_invalid': '1990-03-31T00:00:00'
         }
         assert exporter.detail_items == [
             {'first_name': 'First', 'last_name': 'Last'},


### PR DESCRIPTION
Added tests for valid and invalid dates in the exporter using the `_get_datapoint_date_value` method.

Also updated the method to safely convert datetimes. Only datetimes with the format `YYYY-MM-DD` are accepted now.